### PR TITLE
Various syntax changes

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -31,11 +31,10 @@ function _installfork(){
     old_dir="${old_dir}.${old_count}"
   fi
 
-  echo "using: ${old_dir}"
-  #echo "Moving current openpilot installation to /data/openpilot.old"
-  #mv /data/openpilot /data/openpilot.old
-  #echo "Fork will be installed to /data/openpilot"
-  #git clone $1 /data/openpilot
+  echo "Moving current openpilot installation to ${old_dir}"
+  mv /data/openpilot ${old_dir}
+  echo "Fork will be installed to /data/openpilot"
+  git clone $1 /data/openpilot
 }
 
 function _updatedotfiles(){

--- a/.bashrc
+++ b/.bashrc
@@ -4,18 +4,41 @@ if [ -x "$(command -v powerline-shell)" ]; then
   source /home/.powerline
 fi
 
-function pandaflash() {
+function _pandaflash() {
   cd /data/openpilot/panda/board && make recover
 }
 
-function pandaflash2() {
+function _pandaflash2() {
   cd /data/openpilot/panda; pkill -f boardd; PYTHONPATH=..; python -c "from panda import Panda; Panda().flash()"
 }
 
-function controlsdebug(){
+function _controlsdebug(){
   pkill -f controlsd ; PYTHONPATH=/data/openpilot python /data/openpilot/selfdrive/controls/controlsd.py 2>&1 | tee /data/output.log
 }
 
-function updatedotfiles(){
+function _updatedotfiles(){
   git -C /home/comma-dotfiles pull ; python /home/comma-dotfiles/install.py
+}
+
+function dotfiles(){
+  if [ $# < 1]; then
+    echo "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
+
+  if [ $1 = "update" ]; then
+    _updatedotfiles
+
+  elif [ $1 = "pandaflash" ]; then
+    _pandaflash
+
+  elif [ $1 = "pandaflash2" ]; then
+    _pandaflash2
+
+  elif [ $1 = "debug" ]; then
+    if [ $2 = "controls" ]; then
+      _controlsdebug
+    else
+      echo "Unsupported debugging command!"
+  else
+    echo "Unsupported command!"
+  fi
 }

--- a/.bashrc
+++ b/.bashrc
@@ -21,9 +21,9 @@ function _installfork(){
     echo "You must specify a fork URL to clone!"
     return 1
   fi
-  old_dir="/data/openpilot"
+  old_dir="/data/openpilot.old"
   old_count=0
-  if [ -d "/data/openpilot.old" ]; then
+  if [ -d $old_dir ]; then
     while [ -d "/data/openpilot.old${old_count}" ]; do
       old_count=$((old_count+1))
     done

--- a/.bashrc
+++ b/.bashrc
@@ -22,8 +22,8 @@ function _updatedotfiles(){
 
 function dotfiles(){
   if [ $# -lt 1 ]; then
-    printf "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
-    exit 1
+    printf "You must give a command for dotfiles. Some options are\n- update\n- pandaflash\n- debug"
+    return 1
   fi
 
 }

--- a/.bashrc
+++ b/.bashrc
@@ -31,8 +31,14 @@ function dotfiles(){
   elif [ $1 = "pandaflash" ]; then
     _pandaflash
   elif [ $1 = "pandaflash2" ]; then
-    echo "here"
     _pandaflash2
+  elif [ $1 = "debug" ]; then
+    if [ $2 = "controls" ]; then
+      _controlsdebug
+    else
+      echo "Unsupported debugging command!"
+  else
+    echo "Unsupported command!"
   fi
 
 }

--- a/.bashrc
+++ b/.bashrc
@@ -1,3 +1,4 @@
+cd /data
 cd /data/openpilot
 
 if [ -x "$(command -v powerline-shell)" ]; then
@@ -18,12 +19,12 @@ function _controlsdebug(){
 
 function _installfork(){
   if [ $# -lt 1 ]; then
-      echo "You must specify a fork URL to clone!"
-      return 1
+    echo "You must specify a fork URL to clone!"
+    return 1
   fi
   echo "Moving current openpilot installation to /data/openpilot.old"
+  echo "Fork will be installed to /data/openpilot"
   mv /data/openpilot /data/openpilot.old ; git clone $1 /data/openpilot
-  echo "Cloned fork to /data/openpilot"
 }
 
 function _updatedotfiles(){

--- a/.bashrc
+++ b/.bashrc
@@ -33,6 +33,11 @@ function dotfiles(){
   elif [ $1 = "pandaflash2" ]; then
     _pandaflash2
   elif [ $1 = "debug" ]; then
+    if [ $# -lt 2 ]; then  # verify at least two arguments
+      printf "You must specify a command for dotfiles debug. Some options are\n- controls\n"
+      return 1
+    fi
+
     if [ $2 = "controls" ]; then
       _controlsdebug
     else

--- a/.bashrc
+++ b/.bashrc
@@ -23,8 +23,9 @@ function _installfork(){
     return 1
   fi
   echo "Moving current openpilot installation to /data/openpilot.old"
+  mv /data/openpilot /data/openpilot.old
   echo "Fork will be installed to /data/openpilot"
-  mv /data/openpilot /data/openpilot.old ; git clone $1 /data/openpilot
+  git clone $1 /data/openpilot
 }
 
 function _updatedotfiles(){

--- a/.bashrc
+++ b/.bashrc
@@ -51,11 +51,11 @@ function dotfiles(){
     if [ $2 = "controls" ]; then
       _controlsdebug
     else
-      echo "Unsupported debugging command! Try one of these commands:"
+      printf "Unsupported debugging command! Try one of these commands:"
       printf '%s\n' "$debugging_commands"
     fi
   else
-    echo "Unsupported command! Try one of these commands:"
+    printf "Unsupported command! Try one of these commands:"
     printf '%s\n' "$commands"
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -28,7 +28,7 @@ function dotfiles(){
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    echo $functions
+    # echo $functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -22,8 +22,12 @@ function _updatedotfiles(){
 
 function dotfiles(){
   if [ $# -lt 1 ]; then
-    printf "You must give a command for dotfiles. Some options are\n- update\n- pandaflash\n- debug\n\n"
+    printf "You must specify a command for dotfiles. Some options are\n- update\n- pandaflash\n- debug\n"
     return 1
+  fi
+
+  if [ $1 = "update" ]; then
+    _updatedotfiles
   fi
 
 }

--- a/.bashrc
+++ b/.bashrc
@@ -28,6 +28,8 @@ function dotfiles(){
 
   if [ $1 = "update" ]; then
     _updatedotfiles
+  elif [ $1 = "pandaflash" ]; then
+    _pandaflash
   fi
 
 }

--- a/.bashrc
+++ b/.bashrc
@@ -21,7 +21,8 @@ function _updatedotfiles(){
 }
 
 function dotfiles(){
-  commands="- update - updates this tool, requires restart of ssh session
+  commands="
+  - update - updates this tool, requires restart of ssh session
   - pandaflash - flashes panda
   - pandaflash2 - flashes panda without make recover
   - debug - debugging tools"

--- a/.bashrc
+++ b/.bashrc
@@ -22,7 +22,7 @@ function _updatedotfiles(){
 
 function dotfiles(){
   if [ $# -lt 1 ]; then
-    echo "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
+    printf "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
     exit 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -28,7 +28,7 @@ function dotfiles(){
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    printf "%s\n" > functions
+    printf $functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -36,7 +36,8 @@ function dotfiles(){  # main wrapper function
   - update: updates this tool, requires restart of ssh session
   - pandaflash: flashes panda
   - pandaflash2: flashes panda without make recover
-  - debug: debugging tools"
+  - debug: debugging tools
+  - installfork: Specify the fork URL after. Moves openpilot to openpilot.old"
   debugging_commands="
   - controls: logs controls to /data/output.log"
 

--- a/.bashrc
+++ b/.bashrc
@@ -28,7 +28,7 @@ function dotfiles(){
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    printf $functions
+    echo $functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -24,11 +24,11 @@ function dotfiles(){
   functions = "- update - updates this tool, requires restart of ssh session
   - pandaflash - flashes panda
   - pandaflash2 - flashes panda without make recover
-  - debug - debugging tools\n"
+  - debug - debugging tools"
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    printf functions
+    printf "%s\n" > functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -23,10 +23,10 @@ function _updatedotfiles(){
 function dotfiles(){
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are
-    - update - updates this tool, requires restart of ssh session
-    - pandaflash - flashes panda
-    - pandaflash2 - flashes panda without make recover
-    - debug - debugging tools\n"
+  - update - updates this tool, requires restart of ssh session
+  - pandaflash - flashes panda
+  - pandaflash2 - flashes panda without make recover
+  - debug - debugging tools\n"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -23,7 +23,7 @@ function _updatedotfiles(){
 function dotfiles(){
   if [ $# -lt 1 ]; then
     echo "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
-    return [n]
+    exit 1
   fi
 
 }

--- a/.bashrc
+++ b/.bashrc
@@ -52,7 +52,7 @@ function dotfiles(){  # main wrapper function
   elif [ $1 = "pandaflash2" ]; then
     _pandaflash2
   elif [ $1 = "installfork" ]; then
-    _installfork
+    _installfork $2
   elif [ $1 = "debug" ]; then
     if [ $# -lt 2 ]; then  # verify at least two arguments
       printf "You must specify a command for dotfiles debug. Some options are:"

--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,14 @@
 cd /data ; cd /data/openpilot  # just in case openpilot is missing, default to /data
 
+commands="
+  - update: updates this tool, requires restart of ssh session
+  - pandaflash: flashes panda
+  - pandaflash2: flashes panda without make recover
+  - debug: debugging tools
+  - installfork: Specify the fork URL after. Moves openpilot to openpilot.old"
+debugging_commands="
+  - controls: logs controlsd to /data/output.log"
+
 if [ -x "$(command -v powerline-shell)" ]; then
   source /home/.powerline
 fi
@@ -37,20 +46,26 @@ function _installfork(){
   git clone $1 /data/openpilot
 }
 
+function _debug(){
+  if [ $# -lt 1 ]; then  # verify at least two arguments
+    printf "You must specify a command for dotfiles debug. Some options are:"
+    printf '%s\n' "$debugging_commands"
+    return 1
+  fi
+
+  if [ $1 = "controls" ]; then
+    _controlsdebug
+  else
+    printf "Unsupported debugging command! Try one of these:"
+    printf '%s\n' "$debugging_commands"
+  fi
+}
+
 function _updatedotfiles(){
   git -C /home/comma-dotfiles pull ; python /home/comma-dotfiles/install.py
 }
 
 function emu(){  # main wrapper function
-  commands="
-  - update: updates this tool, requires restart of ssh session
-  - pandaflash: flashes panda
-  - pandaflash2: flashes panda without make recover
-  - debug: debugging tools
-  - installfork: Specify the fork URL after. Moves openpilot to openpilot.old"
-  debugging_commands="
-  - controls: logs controlsd to /data/output.log"
-
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are:"
     printf '%s\n' "$commands"
@@ -66,18 +81,7 @@ function emu(){  # main wrapper function
   elif [ $1 = "installfork" ]; then
     _installfork $2
   elif [ $1 = "debug" ]; then
-    if [ $# -lt 2 ]; then  # verify at least two arguments
-      printf "You must specify a command for dotfiles debug. Some options are:"
-      printf '%s\n' "$debugging_commands"
-      return 1
-    fi
-
-    if [ $2 = "controls" ]; then
-      _controlsdebug
-    else
-      printf "Unsupported debugging command! Try one of these:"
-      printf '%s\n' "$debugging_commands"
-    fi
+    _debug $2
   else
     printf "Unsupported command! Try one of these:"
     printf '%s\n' "$commands"

--- a/.bashrc
+++ b/.bashrc
@@ -38,7 +38,8 @@ function dotfiles(){
     _pandaflash2
   elif [ $1 = "debug" ]; then
     if [ $# -lt 2 ]; then  # verify at least two arguments
-      printf "You must specify a command for dotfiles debug. Some options are\n- controls\n"
+      printf "You must specify a command for dotfiles debug. Some options are
+  - controls\n"
       return 1
     fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -21,14 +21,16 @@ function _installfork(){
     echo "You must specify a fork URL to clone!"
     return 1
   fi
+
   old_dir="/data/openpilot.old"
   old_count=0
   if [ -d $old_dir ]; then
-    while [ -d "/data/openpilot.old${old_count}" ]; do
-      old_count=$((old_count+1))
+    while [ -d "/data/openpilot.old.${old_count}" ]; do
+      old_count=$((old_count+1))  # counts until we find an unused dir name
     done
-    old_dir="${old_dir}${old_count}"
+    old_dir="${old_dir}.${old_count}"
   fi
+
   echo "using: ${old_dir}"
   #echo "Moving current openpilot installation to /data/openpilot.old"
   #mv /data/openpilot /data/openpilot.old

--- a/.bashrc
+++ b/.bashrc
@@ -22,7 +22,7 @@ function _updatedotfiles(){
 
 function dotfiles(){
   if [ $# -lt 1 ]; then
-    printf "You must give a command for dotfiles. Some options are\n- update\n- pandaflash\n- debug"
+    printf "You must give a command for dotfiles. Some options are\n- update\n- pandaflash\n- debug\n\n"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -21,7 +21,7 @@ function _updatedotfiles(){
 }
 
 function dotfiles(){
-  if [ $# -lt 1]; then
+  if [ $# -lt 1 ]; then
     echo "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
     return [n]
   fi

--- a/.bashrc
+++ b/.bashrc
@@ -25,7 +25,7 @@ function dotfiles(){
     echo "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
     return [n]
   fi
-
+<<COMMENT1
   if [ $1 = "update" ]; then
     _updatedotfiles
 
@@ -43,4 +43,5 @@ function dotfiles(){
   else
     echo "Unsupported command!"
   fi
+COMMENT1
 }

--- a/.bashrc
+++ b/.bashrc
@@ -21,27 +21,9 @@ function _updatedotfiles(){
 }
 
 function dotfiles(){
-  if [ $# < 1]; then
+  if [ $# -lt 1]; then
     echo "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
     return [n]
   fi
-<<COMMENT1
-  if [ $1 = "update" ]; then
-    _updatedotfiles
 
-  elif [ $1 = "pandaflash" ]; then
-    _pandaflash
-
-  elif [ $1 = "pandaflash2" ]; then
-    _pandaflash2
-
-  elif [ $1 = "debug" ]; then
-    if [ $2 = "controls" ]; then
-      _controlsdebug
-    else
-      echo "Unsupported debugging command!"
-  else
-    echo "Unsupported command!"
-  fi
-COMMENT1
 }

--- a/.bashrc
+++ b/.bashrc
@@ -22,12 +22,12 @@ function _updatedotfiles(){
 
 function dotfiles(){
   commands="
-  - update - updates this tool, requires restart of ssh session
-  - pandaflash - flashes panda
-  - pandaflash2 - flashes panda without make recover
-  - debug - debugging tools"
+  - update: updates this tool, requires restart of ssh session
+  - pandaflash: flashes panda
+  - pandaflash2: flashes panda without make recover
+  - debug: debugging tools"
   debugging_commands="
-  - controls - logs controls to /data/output.log"
+  - controls: logs controls to /data/output.log"
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are:"

--- a/.bashrc
+++ b/.bashrc
@@ -73,5 +73,4 @@ function dotfiles(){  # main wrapper function
     printf "Unsupported command! Try one of these:"
     printf '%s\n' "$commands"
   fi
-
 }

--- a/.bashrc
+++ b/.bashrc
@@ -22,7 +22,11 @@ function _updatedotfiles(){
 
 function dotfiles(){
   if [ $# -lt 1 ]; then
-    printf "You must specify a command for dotfiles. Some options are\n- update\n- pandaflash\n- debug\n"
+    printf "You must specify a command for dotfiles. Some options are
+            \n- update - updates this tool, requires restart of ssh session
+            \n- pandaflash - flashes panda
+            \n- pandaflash2 - flashes panda without make recover
+            \n- debug - debugging tools\n"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -31,6 +31,7 @@ function dotfiles(){
   elif [ $1 = "pandaflash" ]; then
     _pandaflash
   elif [ $1 = "pandaflash2" ]; then
+    echo "here"
     _pandaflash2
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -23,10 +23,10 @@ function _updatedotfiles(){
 function dotfiles(){
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are
-            \n- update - updates this tool, requires restart of ssh session
-            \n- pandaflash - flashes panda
-            \n- pandaflash2 - flashes panda without make recover
-            \n- debug - debugging tools\n"
+            - update - updates this tool, requires restart of ssh session
+            - pandaflash - flashes panda
+            - pandaflash2 - flashes panda without make recover
+            - debug - debugging tools\n"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -37,6 +37,7 @@ function dotfiles(){
       _controlsdebug
     else
       echo "Unsupported debugging command!"
+    fi
   else
     echo "Unsupported command!"
   fi

--- a/.bashrc
+++ b/.bashrc
@@ -27,8 +27,8 @@ function dotfiles(){
   - debug - debugging tools"
 
   if [ $# -lt 1 ]; then
-    printf "You must specify a command for dotfiles. Some options are"
-    printf '%s' "$commands"
+    printf "You must specify a command for dotfiles. Some options are\n"
+    printf '%s\n' "$commands"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -21,14 +21,14 @@ function _updatedotfiles(){
 }
 
 function dotfiles(){
-  functions = "- update - updates this tool, requires restart of ssh session
+  functions="- update - updates this tool, requires restart of ssh session
   - pandaflash - flashes panda
   - pandaflash2 - flashes panda without make recover
   - debug - debugging tools"
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    # echo $functions
+    echo $functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -23,6 +23,8 @@ function _updatedotfiles(){
 function dotfiles(){
   if [ $# < 1]; then
     echo "You must give a command for dotfiles. Some are\n- update\n- pandaflash\n- debug"
+    return [n]
+  fi
 
   if [ $1 = "update" ]; then
     _updatedotfiles

--- a/.bashrc
+++ b/.bashrc
@@ -23,10 +23,10 @@ function _updatedotfiles(){
 function dotfiles(){
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are
-            - update - updates this tool, requires restart of ssh session
-            - pandaflash - flashes panda
-            - pandaflash2 - flashes panda without make recover
-            - debug - debugging tools\n"
+    - update - updates this tool, requires restart of ssh session
+    - pandaflash - flashes panda
+    - pandaflash2 - flashes panda without make recover
+    - debug - debugging tools\n"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -39,7 +39,7 @@ function dotfiles(){  # main wrapper function
   - debug: debugging tools
   - installfork: Specify the fork URL after. Moves openpilot to openpilot.old"
   debugging_commands="
-  - controls: logs controls to /data/output.log"
+  - controls: logs controlsd to /data/output.log"
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are:"

--- a/.bashrc
+++ b/.bashrc
@@ -28,7 +28,7 @@ function dotfiles(){
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    echo -e $functions
+    printf "$functions"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -26,9 +26,11 @@ function dotfiles(){
   - pandaflash - flashes panda
   - pandaflash2 - flashes panda without make recover
   - debug - debugging tools"
+  debugging_commands="
+  - controls - logs controls to /data/output.log"
 
   if [ $# -lt 1 ]; then
-    printf "You must specify a command for dotfiles. Some options are\n"
+    printf "You must specify a command for dotfiles. Some options are:"
     printf '%s\n' "$commands"
     return 1
   fi
@@ -41,15 +43,16 @@ function dotfiles(){
     _pandaflash2
   elif [ $1 = "debug" ]; then
     if [ $# -lt 2 ]; then  # verify at least two arguments
-      printf "You must specify a command for dotfiles debug. Some options are
-  - controls\n"
+      printf "You must specify a command for dotfiles debug. Some options are:"
+      printf '%s\n' "$debugging_commands"
       return 1
     fi
 
     if [ $2 = "controls" ]; then
       _controlsdebug
     else
-      echo "Unsupported debugging command!"
+      echo "Unsupported debugging command! Try one of these commands:"
+      printf '%s\n' "$commands"
     fi
   else
     echo "Unsupported command!"

--- a/.bashrc
+++ b/.bashrc
@@ -52,10 +52,11 @@ function dotfiles(){
       _controlsdebug
     else
       echo "Unsupported debugging command! Try one of these commands:"
-      printf '%s\n' "$commands"
+      printf '%s\n' "$debugging_commands"
     fi
   else
-    echo "Unsupported command!"
+    echo "Unsupported command! Try one of these commands:"
+    printf '%s\n' "$commands"
   fi
 
 }

--- a/.bashrc
+++ b/.bashrc
@@ -28,7 +28,7 @@ function dotfiles(){
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    echo $functions
+    printf $functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -16,11 +16,21 @@ function _controlsdebug(){
   pkill -f controlsd ; PYTHONPATH=/data/openpilot python /data/openpilot/selfdrive/controls/controlsd.py 2>&1 | tee /data/output.log
 }
 
+function _installfork(){
+  if [ $# -lt 1 ]; then
+      echo "You must specify a fork URL to clone!"
+      return 1
+  fi
+  echo "Moving current openpilot installation to /data/openpilot.old"
+  mv /data/openpilot /data/openpilot.old ; git clone $1 /data/openpilot
+  echo "Cloned fork to /data/openpilot"
+}
+
 function _updatedotfiles(){
   git -C /home/comma-dotfiles pull ; python /home/comma-dotfiles/install.py
 }
 
-function dotfiles(){
+function dotfiles(){  # main wrapper function
   commands="
   - update: updates this tool, requires restart of ssh session
   - pandaflash: flashes panda
@@ -41,6 +51,8 @@ function dotfiles(){
     _pandaflash
   elif [ $1 = "pandaflash2" ]; then
     _pandaflash2
+  elif [ $1 = "installfork" ]; then
+    _installfork
   elif [ $1 = "debug" ]; then
     if [ $# -lt 2 ]; then  # verify at least two arguments
       printf "You must specify a command for dotfiles debug. Some options are:"
@@ -51,11 +63,11 @@ function dotfiles(){
     if [ $2 = "controls" ]; then
       _controlsdebug
     else
-      printf "Unsupported debugging command! Try one of these commands:"
+      printf "Unsupported debugging command! Try one of these:"
       printf '%s\n' "$debugging_commands"
     fi
   else
-    printf "Unsupported command! Try one of these commands:"
+    printf "Unsupported command! Try one of these:"
     printf '%s\n' "$commands"
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -21,12 +21,14 @@ function _updatedotfiles(){
 }
 
 function dotfiles(){
-  if [ $# -lt 1 ]; then
-    printf "You must specify a command for dotfiles. Some options are
-  - update - updates this tool, requires restart of ssh session
+  functions = "- update - updates this tool, requires restart of ssh session
   - pandaflash - flashes panda
   - pandaflash2 - flashes panda without make recover
   - debug - debugging tools\n"
+
+  if [ $# -lt 1 ]; then
+    printf "You must specify a command for dotfiles. Some options are"
+    printf functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -21,13 +21,15 @@ function _installfork(){
     echo "You must specify a fork URL to clone!"
     return 1
   fi
+  old_dir="/data/openpilot"
   old_count=0
   if [ -d "/data/openpilot.old" ]; then
     while [ -d "/data/openpilot.old${old_count}" ]; do
       old_count=$((old_count+1))
     done
+    old_dir="${old_dir}${old_count}"
   fi
-  echo "using: /data/openpilot.old${old_count}"
+  echo "using: ${old_dir}"
   #echo "Moving current openpilot installation to /data/openpilot.old"
   #mv /data/openpilot /data/openpilot.old
   #echo "Fork will be installed to /data/openpilot"

--- a/.bashrc
+++ b/.bashrc
@@ -21,14 +21,14 @@ function _updatedotfiles(){
 }
 
 function dotfiles(){
-  functions="- update - updates this tool, requires restart of ssh session
+  commands="- update - updates this tool, requires restart of ssh session
   - pandaflash - flashes panda
   - pandaflash2 - flashes panda without make recover
   - debug - debugging tools"
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    printf "$functions"
+    printf '%s' "$commands"
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,4 @@
-cd /data
-cd /data/openpilot
+cd /data ; cd /data/openpilot  # just in case openpilot is missing, default to /data
 
 if [ -x "$(command -v powerline-shell)" ]; then
   source /home/.powerline
@@ -22,17 +21,24 @@ function _installfork(){
     echo "You must specify a fork URL to clone!"
     return 1
   fi
-  echo "Moving current openpilot installation to /data/openpilot.old"
-  mv /data/openpilot /data/openpilot.old
-  echo "Fork will be installed to /data/openpilot"
-  git clone $1 /data/openpilot
+  old_count=0
+  if [ -d "/data/openpilot.old" ]; then
+    while [ -d "/data/openpilot.old${old_count}" ]; do
+      old_count=$((old_count+1))
+    done
+  fi
+  echo "using: /data/openpilot.old${old_count}"
+  #echo "Moving current openpilot installation to /data/openpilot.old"
+  #mv /data/openpilot /data/openpilot.old
+  #echo "Fork will be installed to /data/openpilot"
+  #git clone $1 /data/openpilot
 }
 
 function _updatedotfiles(){
   git -C /home/comma-dotfiles pull ; python /home/comma-dotfiles/install.py
 }
 
-function dotfiles(){  # main wrapper function
+function emu(){  # main wrapper function
   commands="
   - update: updates this tool, requires restart of ssh session
   - pandaflash: flashes panda

--- a/.bashrc
+++ b/.bashrc
@@ -28,7 +28,7 @@ function dotfiles(){
 
   if [ $# -lt 1 ]; then
     printf "You must specify a command for dotfiles. Some options are"
-    printf $functions
+    echo -e $functions
     return 1
   fi
 

--- a/.bashrc
+++ b/.bashrc
@@ -30,6 +30,8 @@ function dotfiles(){
     _updatedotfiles
   elif [ $1 = "pandaflash" ]; then
     _pandaflash
+  elif [ $1 = "pandaflash2" ]; then
+    _pandaflash2
   fi
 
 }

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ python /home/comma-dotfiles/install.py
 **Note, running `install.py` assumes you used the above command to clone this repository to `/home/comma-dotfiles`. If you installed `powerline`, it will be automatically detected and the config files will be copied.**
 
 # Updating
-To update `comma-dotfiles`, run the `updatedotfiles` command via:
+To update `comma-dotfiles`, run the `update` command via:
 ```
-updatedotfiles
+dotfiles update
 ```
 This will essentially perform a git pull and replace all current files in the `/home` directory with new ones, if an update is available.
 
@@ -31,12 +31,15 @@ The goal is to get `.bashrc` and the `.config` folder in the `/home/` folder
 The default directory of your bash/ssh session is now `/data/openpilot`. Much easier to git pull after shelling in!
 
 # Commands
+### General
+- `dotfiles installfork https://github.com/...`: Clones the fork URL to `/data/openpilot`. Current folder is moved to `/data/openpilot.old` before cloning
+
 ### Panda
-- `pandaflash`: Flashes the panda
-- `pandaflash2`: Flashes the panda without `make recover`
+- `dotfiles pandaflash`: Flashes the panda
+- `dotfiles pandaflash2`: Flashes the panda without `make recover`
 
 ### Debugging
-- `controlsdebug`: You can debug controlsd and output it to a log of `/data/output.log`
+- `dotfiles debug controlsd`: You can debug controlsd and output it to a log of `/data/output.log`
 
 # Git config
 While you're in a rw filesystem, you might as well edit your git config so you can push your changes up easily.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The default directory of your bash/ssh session is now `/data/openpilot`. Much ea
 - `dotfiles pandaflash2`: Flashes the panda without `make recover`
 
 ### Debugging
-- `dotfiles debug controlsd`: You can debug controlsd and output it to a log of `/data/output.log`
+- `dotfiles debug controls`: You can debug controlsd and output it to a log file `/data/output.log`
 
 # Git config
 While you're in a rw filesystem, you might as well edit your git config so you can push your changes up easily.

--- a/install.py
+++ b/install.py
@@ -33,4 +33,4 @@ def main():
 if __name__ == "__main__":
   print('Running installation...')
   main()
-  print('Finished! Remember to reconnect to finish update.')
+  print('Finished! Remember to reconnect to finish the install/update.')

--- a/install.py
+++ b/install.py
@@ -33,4 +33,4 @@ def main():
 if __name__ == "__main__":
   print('Running installation...')
   main()
-  print('Finished! Remember to reconnect to finish the install/update.')
+  print('\nFinished! Remember to reconnect to finish the install/update.')

--- a/install.py
+++ b/install.py
@@ -33,4 +33,4 @@ def main():
 if __name__ == "__main__":
   print('Running installation...')
   main()
-  print('Finished!')
+  print('Finished! Remember to reconnect to finish update.')


### PR DESCRIPTION
- Unify all commands under one `emu` command.
- Add `installfork` command to clone a fork URL.
- Should probably move most of the argument checking to the individual functions like I did for `installfork` to make the main function cleaner
- cd to `/data` first in the event `/data/openpilot` doesn't exist, we're at least in `/data` then
- Clean up main function, move debug check to `_debug` sub-function

Example: `updatedotfiles` becomes `emu update`

![Screenshot_626](https://user-images.githubusercontent.com/25857203/84425386-1701a400-abe7-11ea-97ce-77185d46d005.png)
